### PR TITLE
feat(explore): auto-focus search input in Change Visualization Type modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeControl.test.tsx
@@ -245,6 +245,16 @@ describe('VizTypeControl', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('Search input is focusable when modal opens', async () => {
+    await waitForRenderWrapper();
+
+    const searchInput = screen.getByTestId(getTestId('search-input'));
+    
+    // Verify that the search input can be focused
+    searchInput.focus();
+    expect(searchInput).toHaveFocus();
+  });
+
   it('Submit on viz type double-click', async () => {
     await waitForRenderWrapper();
     userEvent.click(screen.getByRole('button', { name: 'ballot All charts' }));

--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -443,6 +443,16 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(true);
   const isActivelySearching = isSearchFocused && !!searchInputValue;
 
+  // Auto-focus the search input when the modal opens
+  useEffect(() => {
+    if (searchInputRef.current) {
+      // Use setTimeout to ensure the modal is fully rendered
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 0);
+    }
+  }, []); // Empty dependency array - runs only on mount
+
   const selectedVizMetadata: ChartMetadata | null = selectedViz
     ? mountedPluginMetadata[selectedViz]
     : null;


### PR DESCRIPTION
### SUMMARY

Improves user experience by automatically focusing the search input when the "Change Visualization Type" modal opens in Explore view. Users can now immediately start typing to search for visualization types without needing an extra click.

**What Changed:**
- Added `useEffect` hook in `VizTypeGallery.tsx` that auto-focuses the search input when modal opens
- Used `setTimeout(0)` to ensure modal is fully rendered before focusing
- Added test to verify search input is focusable

**Why:**
- Reduces friction during chart creation workflow
- Aligns with common modal interaction patterns
- Improves keyboard navigation for power users

### BEFORE/AFTER VIDEOS

**BEFORE:**

https://github.com/user-attachments/assets/987b25fc-d56a-43ab-a228-2a85095690bc


**AFTER:**

https://github.com/user-attachments/assets/715b021b-a82d-49ca-870a-649f3a6296cf

**VIDEO DEMO:**

https://github.com/user-attachments/assets/68ff9c17-681e-4770-88cc-c61b74b1d928


### TESTING INSTRUCTIONS

**Manual Testing:**
1. Open any chart in Explore view
2. Click "View all charts" button (or click current chart type icon)
3. Verify the "Change Visualization Type" modal opens
4. **Expected:** Cursor automatically appears in search input (blinking cursor visible)
5. Immediately start typing (e.g., "bar") without clicking
6. **Expected:** Chart types filter as you type

**Automated Testing:**
```bash
cd superset-frontend
npm test -- --testPathPattern="VizTypeControl" --watchAll=false
```
Expected: All 10 tests pass

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #6 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API