### PR TITLE
fix(sql-lab): prevent hiding strings with angle brackets in query results

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -54,6 +54,7 @@ export function hasHtmlTagPattern(str: string): boolean {
 export function isProbablyHTML(text: string) {
   const cleanedStr = text.trim().toLowerCase();
 
+  // Only detect HTML for complete documents or obvious HTML patterns
   if (
     cleanedStr.startsWith('<!doctype html>') &&
     hasHtmlTagPattern(cleanedStr)
@@ -61,9 +62,33 @@ export function isProbablyHTML(text: string) {
     return true;
   }
 
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(cleanedStr, 'text/html');
-  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
+  // Check for complete HTML document patterns
+  if (
+    cleanedStr.startsWith('<html') ||
+    cleanedStr.startsWith('<head') ||
+    cleanedStr.startsWith('<body')
+  ) {
+    return true;
+  }
+
+  // Check for multiple HTML tags (more likely to be intentional HTML)
+  const htmlTagCount = (cleanedStr.match(/<[^>]+>/g) || []).length;
+  if (htmlTagCount >= 2) {
+    return true;
+  }
+
+  // For single tag patterns, be more conservative
+  // Only treat as HTML if it looks like a complete, intentional HTML structure
+  const singleTagPattern = /^<[a-z][a-z0-9]*[^>]*>.*<\/[a-z][a-z0-9]*>$/i;
+  if (singleTagPattern.test(text.trim())) {
+    // Additional check: ensure it's not just angle brackets in text
+    const tagName = text.trim().match(/^<([a-z][a-z0-9]*)/i)?.[1];
+    if (tagName && ['div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'strong', 'em', 'b', 'i'].includes(tagName.toLowerCase())) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {
@@ -73,10 +98,18 @@ export function sanitizeHtmlIfNeeded(htmlString: string) {
 export function safeHtmlSpan(possiblyHtmlString: string) {
   const isHtml = isProbablyHTML(possiblyHtmlString);
   if (isHtml) {
+    const sanitizedHtml = sanitizeHtml(possiblyHtmlString);
+    
+    // Fallback: If sanitization removes all content, treat as plain text
+    // This prevents data loss when XSS filter is too aggressive
+    if (sanitizedHtml.trim() === '' && possiblyHtmlString.trim() !== '') {
+      return possiblyHtmlString;
+    }
+    
     return (
       <span
         className="safe-html-wrapper"
-        dangerouslySetInnerHTML={{ __html: sanitizeHtml(possiblyHtmlString) }}
+        dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
       />
     );
   }


### PR DESCRIPTION
### SUMMARY
Query results in SQL Lab containing strings with angle brackets were being hidden from display. Strings like `<test>`, `x < 5`, `Name <email@example.com>`, and `List<String>` appeared as empty cells even though the data existed in the API response.

**Root Cause:**

The `isProbablyHTML()` function treated any string with `<` or `>` as HTML. After sanitization via `safeHtmlSpan()`, these strings were often removed entirely, causing data loss in the results grid.

**Solution:**
- Implemented conservative HTML detection that only processes strings as HTML when they contain:
  - Complete HTML documents (with `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>`)
  - Multiple HTML tags (2 or more)
  - Common single HTML elements (div, span, p, h1-h6, a, strong, em, b, i)
- Added fallback logic: if sanitization removes all content, the original string is displayed as plain text
- Maintains XSS protection while ensuring legitimate data remains visible

**Technical Details:**

Modified `superset-frontend/packages/superset-ui-core/src/utils/html.tsx` to improve HTML detection logic and add sanitization fallback.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**BEFORE (Bug):**

<img width="955" height="466" alt="Issue 4 - Before Screenshot" src="https://github.com/user-attachments/assets/e698703b-7ed0-4626-b113-d84b7812b55f" />

**AFTER (Fixed):**

<img width="959" height="419" alt="Issue 4 - After Screenshot" src="https://github.com/user-attachments/assets/622c10f0-6509-4590-9549-f15ce3c1a4ce" />

https://github.com/user-attachments/assets/6d6a3a2b-a65b-49c6-b5a8-9f08c0e34931

### TESTING INSTRUCTIONS

1. Open SQL Lab with any database connection
2. Run these test queries and verify correct display:

```sql
-- Test 1: Simple angle brackets
SELECT '<test>' as value;
-- Expected: Displays "<test>"

-- Test 2: Comparison operators
SELECT 'x < 5' as less_than, 'y > 10' as greater_than;
-- Expected: Both display correctly

-- Test 3: Email format
SELECT 'John Doe <john@example.com>' as email;
-- Expected: Full string visible
```

3. Verify CSV/Excel export contains all data
4. Confirm no XSS vulnerabilities introduced

### ADDITIONAL INFORMATION

- [x] Has associated issue: #5 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [[SIP-59](https://github.com/apache/superset/issues/13351)](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
