### PR TITLE
fix(explore): update browser tab title to show chart name

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -299,3 +299,65 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     expect(formData[key]).toBeUndefined();
   });
 });
+
+describe('document title management', () => {
+  const initialDocumentTitle = document.title;
+
+  beforeEach(() => {
+    document.title = initialDocumentTitle;
+  });
+
+  afterEach(() => {
+    document.title = initialDocumentTitle;
+  });
+
+  test('updates document title when sliceName is provided', async () => {
+    const chartTitle = 'Orders Trend';
+    renderWithRouter({
+      initialState: {
+        ...reduxState,
+        explore: {
+          ...reduxState.explore,
+          slice: {
+            ...reduxState.explore.slice,
+            slice_name: chartTitle,
+          },
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(document.title).toBe(`${chartTitle} | Superset`),
+    );
+  });
+
+  test('falls back to original document title when sliceName is absent', async () => {
+    renderWithRouter({ initialState: reduxState });
+
+    await waitFor(() => expect(document.title).toBe(initialDocumentTitle));
+  });
+
+  test('restores original title on unmount', async () => {
+    const chartTitle = 'Sales Overview';
+    const { unmount } = renderWithRouter({
+      initialState: {
+        ...reduxState,
+        explore: {
+          ...reduxState.explore,
+          slice: {
+            ...reduxState.explore.slice,
+            slice_name: chartTitle,
+          },
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(document.title).toBe(`${chartTitle} | Superset`),
+    );
+
+    unmount();
+
+    expect(document.title).toBe(initialDocumentTitle);
+  });
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -71,6 +71,8 @@ import DataSourcePanel from '../DatasourcePanel';
 import ConnectedExploreChartHeader from '../ExploreChartHeader';
 import ExploreContainer from '../ExploreContainer';
 
+const originalDocumentTitle = document.title;
+
 const propTypes = {
   ...ExploreChartPanel.propTypes,
   actions: PropTypes.object.isRequired,
@@ -368,6 +370,17 @@ function ExploreViewContainer(props) {
         : undefined,
     );
   });
+
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = `${props.sliceName} | Superset`;
+    } else {
+      document.title = originalDocumentTitle;
+    }
+    return () => {
+      document.title = originalDocumentTitle;
+    };
+  }, [props.sliceName]);
 
   useChangeEffect(tabId, (previous, current) => {
     if (current) {


### PR DESCRIPTION
### SUMMARY
Updates the Explore view to dynamically set the browser tab title based on the chart being viewed. When a saved chart is open, the tab title displays `[Chart Name] | Superset` instead of just `Superset`, making it easier for users to identify charts when working with multiple tabs.

**Problem:** Users working with multiple chart tabs had no way to distinguish between them, as all tabs showed only "Superset" in the browser title.

**Solution:** 
- Captures the original document title on component mount
- Updates the title to include the chart name when viewing a saved chart
- Falls back to the original title for unsaved/new charts
- Restores the original title on component unmount to prevent side effects

**Technical Implementation:**
- Uses `useEffect` hook to manage title updates based on `sliceName` prop
- Includes cleanup function to restore title when navigating away
- Adds comprehensive tests covering title updates, fallback behavior, and cleanup

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<img width="957" height="504" alt="Issue 7 - Before Screenshot" src="https://github.com/user-attachments/assets/94981192-930f-4a87-93c7-9fe982bf7a03" />
**Before:** All tabs show only "Superset"

<img width="950" height="500" alt="Issue 7 - After Screenshot" src="https://github.com/user-attachments/assets/9ae76ded-5b1d-4507-ba49-b1c0c2f3e66c" />
**After:** Tabs show "[Chart Name] | Superset"

https://github.com/user-attachments/assets/82051494-66a1-4622-8771-10cc893fd75e

### TESTING INSTRUCTIONS
**Automated Tests:**
```bash
npm test -- ExploreViewContainer.test.tsx
```

**Manual Testing:**
1. Open Superset and navigate to SQL Lab or any saved chart
2. Open the chart in Explore view
3. **Verify:** Browser tab title shows `[Chart Name] | Superset`
4. Create a new chart (unsaved)
5. **Verify:** Browser tab title shows just `Superset`
6. Open multiple saved charts in different tabs
7. **Verify:** Each tab shows its respective chart name
8. Navigate away from Explore view
9. **Verify:** Tab title reverts to the default Superset title

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags: #12 
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API