### PR TITLE
fix(sql-lab): copy saved query link to clipboard before navigation

### DIFF
--- a/superset-frontend/src/features/home/SavedQueries.tsx
+++ b/superset-frontend/src/features/home/SavedQueries.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useCallback, useState, MouseEvent } from 'react';
+import { Link, useHistory } from 'react-router-dom';
 import { styled, SupersetClient, t, useTheme, css } from '@superset-ui/core';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/light';
 import sql from 'react-syntax-highlighter/dist/cjs/languages/hljs/sql';
@@ -28,6 +28,7 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import { Dropdown } from 'src/components/Dropdown';
 import { Menu } from 'src/components/Menu';
 import { copyQueryLink, useListViewResource } from 'src/views/CRUD/hooks';
+import copyTextToClipboard from 'src/utils/copy';
 import ListViewCard from 'src/components/ListViewCard';
 import DeleteModal from 'src/components/DeleteModal';
 import Icons from 'src/components/Icons';
@@ -123,6 +124,7 @@ const SavedQueries = ({
   showThumbnails,
   featureFlag,
 }: SavedQueriesProps) => {
+  const history = useHistory();
   const {
     state: { loading, resourceCollection: queries },
     hasPerm,
@@ -191,6 +193,29 @@ const SavedQueries = ({
       ],
       filters: getFilterValues(tab, WelcomeTable.SavedQueries, user),
     });
+
+  const handleCardClick = useCallback(
+    async (queryId: number, openInNewWindow: boolean) => {
+      const url = `${window.location.origin}/sqllab?savedQueryId=${queryId}`;
+
+      try {
+        // Copy link to clipboard first
+        await copyTextToClipboard(() => Promise.resolve(url));
+        addSuccessToast(t('Link Copied!'));
+      } catch (error) {
+        // If clipboard fails, still navigate but show error toast
+        addDangerToast(t('Sorry, your browser does not support copying.'));
+      }
+
+      // Navigate after clipboard operation completes (or fails)
+      if (openInNewWindow) {
+        window.open(`/sqllab?savedQueryId=${queryId}`);
+      } else {
+        history.push(`/sqllab?savedQueryId=${queryId}`);
+      }
+    },
+    [addDangerToast, addSuccessToast, history],
+  );
 
   const renderMenu = useCallback(
     (query: Query) => (
@@ -298,10 +323,25 @@ const SavedQueries = ({
       {queries.length > 0 ? (
         <CardContainer showThumbnails={showThumbnails}>
           {queries.map(q => (
-            <CardStyles key={q.id}>
+            <CardStyles
+              key={q.id}
+              onClick={(e: MouseEvent) => {
+                // Don't trigger if clicking on the actions menu
+                if (
+                  (e.target as HTMLElement).closest(
+                    '[data-test="card-actions"]',
+                  ) ||
+                  (e.target as HTMLElement).closest('.ant-dropdown')
+                ) {
+                  return;
+                }
+                if (q.id) {
+                  handleCardClick(q.id, e.metaKey || e.ctrlKey);
+                }
+              }}
+            >
               <ListViewCard
                 imgURL=""
-                url={`/sqllab?savedQueryId=${q.id}`}
                 title={q.label}
                 imgFallbackURL="/static/assets/images/empty-query.svg"
                 description={t('Modified %s', q.changed_on_delta_humanized)}

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -26,7 +26,7 @@ import {
   css,
   useTheme,
 } from '@superset-ui/core';
-import { useCallback, useMemo, useState, MouseEvent } from 'react';
+import { useCallback, useMemo, useState, MouseEvent, KeyboardEvent } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import rison from 'rison';
 import {
@@ -61,6 +61,7 @@ import Icons from 'src/components/Icons';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import SavedQueryPreviewModal from 'src/features/queries/SavedQueryPreviewModal';
 import { findPermission } from 'src/utils/findPermission';
+import copyTextToClipboard from 'src/utils/copy';
 
 const PAGE_SIZE = 25;
 const PASSWORDS_NEEDED_MESSAGE = t(
@@ -97,6 +98,16 @@ const StyledTableLabel = styled.div`
 
 const StyledPopoverItem = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.dark2};
+`;
+
+const StyledLink = styled.span`
+  color: ${({ theme }) => theme.colors.primary.base};
+  cursor: pointer;
+  text-decoration: none;
+  
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 function SavedQueryList({
@@ -242,13 +253,28 @@ function SavedQueryList({
   menuData.buttons = subMenuButtons;
 
   // Action methods
-  const openInSqlLab = (id: number, openInNewWindow: boolean) => {
-    if (openInNewWindow) {
-      window.open(`/sqllab?savedQueryId=${id}`);
-    } else {
-      history.push(`/sqllab?savedQueryId=${id}`);
-    }
-  };
+  const openInSqlLab = useCallback(
+    async (id: number, openInNewWindow: boolean) => {
+      const url = `${window.location.origin}/sqllab?savedQueryId=${id}`;
+
+      try {
+        // Copy link to clipboard first
+        await copyTextToClipboard(() => Promise.resolve(url));
+        addSuccessToast(t('Link Copied!'));
+      } catch (error) {
+        // If clipboard fails, still navigate but show error toast
+        addDangerToast(t('Sorry, your browser does not support copying.'));
+      }
+
+      // Navigate after clipboard operation completes (or fails)
+      if (openInNewWindow) {
+        window.open(`/sqllab?savedQueryId=${id}`);
+      } else {
+        history.push(`/sqllab?savedQueryId=${id}`);
+      }
+    },
+    [addDangerToast, addSuccessToast, history],
+  );
 
   const copyQueryLink = useCallback(
     async (savedQuery: SavedQueryObject) => {
@@ -333,7 +359,24 @@ function SavedQueryList({
           row: {
             original: { id, label },
           },
-        }: any) => <Link to={`/sqllab?savedQueryId=${id}`}>{label}</Link>,
+        }: any) => (
+          <StyledLink
+            role="link"
+            tabIndex={0}
+            onClick={(e: MouseEvent) => {
+              e.preventDefault();
+              openInSqlLab(id, e.metaKey || e.ctrlKey);
+            }}
+            onKeyDown={(e: KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openInSqlLab(id, e.metaKey || e.ctrlKey);
+              }
+            }}
+          >
+            {label}
+          </StyledLink>
+        ),
       },
       {
         accessor: 'description',
@@ -479,7 +522,7 @@ function SavedQueryList({
         hidden: true,
       },
     ],
-    [canDelete, canEdit, canExport, copyQueryLink, handleSavedQueryPreview],
+    [canDelete, canEdit, canExport, copyQueryLink, handleSavedQueryPreview, openInSqlLab],
   );
 
   const filters: Filters = useMemo(


### PR DESCRIPTION
### SUMMARY

Fixes a race condition where clicking a saved query to open in SQL Lab would fail to copy the link to clipboard because navigation happened immediately, interrupting the async clipboard operation.

**Changes:**
- Modified `openInSqlLab` to await clipboard operation before navigating
- Replaced direct `Link` components with click handlers in Name column
- Added clipboard copy to home page saved query cards
- Added toast notifications for success/error feedback
- Supports same-window and new-window (Ctrl/Cmd+click) navigation

### BEFORE/AFTER VIDEOS

https://github.com/user-attachments/assets/c03e01c7-9203-4095-be3f-d0a38e1f4535
Before

https://github.com/user-attachments/assets/5f6a16df-d070-4ce0-8744-64edb072196a
After

https://github.com/user-attachments/assets/a39cc219-26f4-45cc-9245-d58e3bb34dab
Code Explanation

### TESTING INSTRUCTIONS

1. Navigate to Saved Queries list (`/savedqueryview/list/`)
2. Click on a saved query name
3. Verify "Link Copied!" toast appears
4. Paste clipboard - should contain: `http://localhost:9000/sqllab?savedQueryId={id}`
5. Test Ctrl/Cmd+click opens in new window with same behavior
6. Test home page saved query cards (`/superset/welcome/`)
7. Verify clicking three-dot menu doesn't trigger navigation
8. Test keyboard navigation (Tab + Enter/Space)

### ADDITIONAL INFORMATION

- [x] Has associated issue: Fixes #21 
- [x] Changes UI
- [ ] Required feature flags:
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API