### PR TITLE
feat(boxplot): add zoom/pan functionality

### DIFF
--- a/superset-frontend/cypress-base/cypress/e2e/explore/visualizations/box_plot.test.js
+++ b/superset-frontend/cypress-base/cypress/e2e/explore/visualizations/box_plot.test.js
@@ -57,4 +57,56 @@ describe('Visualization > Box Plot', () => {
       '.Control[data-test="color_scheme"] .ant-select-selection-item [data-test="supersetColors"]',
     ).should('exist');
   });
+
+  it('should enable data zoom functionality', () => {
+    verify(BOX_PLOT_FORM_DATA);
+
+    // Navigate to Chart Options section
+    cy.get('#controlSections-tab-display').click();
+    cy.get('.Control[data-test="zoomable"]').scrollIntoView();
+
+    // Enable data zoom
+    cy.get('.Control[data-test="zoomable"] input[type="checkbox"]').check({
+      force: true,
+    });
+
+    // Wait for chart to update
+    cy.wait('@getJson');
+
+    // Verify the chart still renders
+    cy.get('.chart-container .box_plot canvas').should('have.length', 1);
+
+    // Verify zoom slider is present (ECharts dataZoom slider)
+    // The slider is rendered as part of the ECharts canvas, so we verify
+    // the chart container is present and the zoom control is enabled
+    cy.get('.chart-container').should('be.visible');
+  });
+
+  it('should disable data zoom functionality', () => {
+    const formDataWithZoom = {
+      ...BOX_PLOT_FORM_DATA,
+      zoomable: true,
+    };
+    verify(formDataWithZoom);
+
+    // Navigate to Chart Options section
+    cy.get('#controlSections-tab-display').click();
+    cy.get('.Control[data-test="zoomable"]').scrollIntoView();
+
+    // Verify zoom is enabled
+    cy.get('.Control[data-test="zoomable"] input[type="checkbox"]').should(
+      'be.checked',
+    );
+
+    // Disable data zoom
+    cy.get('.Control[data-test="zoomable"] input[type="checkbox"]').uncheck({
+      force: true,
+    });
+
+    // Wait for chart to update
+    cy.wait('@getJson');
+
+    // Verify the chart still renders
+    cy.get('.chart-container .box_plot canvas').should('have.length', 1);
+  });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/controlPanel.ts
@@ -36,6 +36,7 @@ import {
   getTemporalColumns,
   sharedControls,
 } from '@superset-ui/chart-controls';
+import { DEFAULT_FORM_DATA } from './types';
 
 const config: ControlPanelConfig = {
   controlPanelSections: [
@@ -154,6 +155,18 @@ const config: ControlPanelConfig = {
               choices: D3_TIME_FORMAT_OPTIONS,
               default: 'smart_date',
               description: D3_FORMAT_DOCS,
+            },
+          },
+        ],
+        [
+          {
+            name: 'zoomable',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Data Zoom'),
+              default: DEFAULT_FORM_DATA.zoomable,
+              renderTrigger: true,
+              description: t('Enable data zooming controls'),
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/transformProps.ts
@@ -39,7 +39,7 @@ import {
 import { convertInteger } from '../utils/convertInteger';
 import { defaultGrid, defaultYAxis } from '../defaults';
 import { getPadding } from '../Timeseries/transformers';
-import { OpacityEnum } from '../constants';
+import { OpacityEnum, TIMESERIES_CONSTANTS } from '../constants';
 import { getDefaultTooltip } from '../utils/tooltip';
 import { Refs } from '../types';
 
@@ -73,6 +73,7 @@ export default function transformProps(
     yAxisTitleMargin,
     yAxisTitlePosition,
     sliceId,
+    zoomable = false,
   } = formData as BoxPlotQueryFormData;
   const refs: Refs = {};
   const colorFn = CategoricalColorNamespace.getScale(colorScheme as string);
@@ -284,6 +285,23 @@ export default function transformProps(
       },
     },
     series,
+    dataZoom: zoomable
+      ? [
+          {
+            type: 'slider',
+            start: TIMESERIES_CONSTANTS.dataZoomStart,
+            end: TIMESERIES_CONSTANTS.dataZoomEnd,
+            bottom: TIMESERIES_CONSTANTS.zoomBottom,
+            xAxisIndex: 0,
+          },
+          {
+            type: 'inside',
+            xAxisIndex: 0,
+            zoomOnMouseWheel: false,
+            moveOnMouseWheel: true,
+          },
+        ]
+      : [],
   };
 
   return {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/BoxPlot/types.ts
@@ -30,6 +30,7 @@ export type BoxPlotQueryFormData = QueryFormData & {
   numberFormat?: string;
   whiskerOptions?: BoxPlotFormDataWhiskerOptions;
   xTickLayout?: BoxPlotFormXTickLayout;
+  zoomable?: boolean;
 } & TitleFormData;
 
 export type BoxPlotFormDataWhiskerOptions =
@@ -50,6 +51,7 @@ export type BoxPlotFormXTickLayout =
 // @ts-ignore
 export const DEFAULT_FORM_DATA: BoxPlotQueryFormData = {
   ...DEFAULT_TITLE_FORM_DATA,
+  zoomable: false,
 };
 
 export interface EchartsBoxPlotChartProps


### PR DESCRIPTION
### SUMMARY

BoxPlot charts lacked interactive zoom capabilities, making it difficult to explore datasets with many categories. This adds the same zoom functionality used in Timeseries charts.

When enabled via the "Data Zoom" checkbox in Chart Options, users can pan through categories using a bottom slider or mouse wheel. The feature is disabled by default.

**Changes:**
- Add `zoomable` field to BoxPlotQueryFormData type
- Add "Data Zoom" checkbox control in Chart Options
- Configure ECharts dataZoom for categorical x-axis (slider + inside types)
- Add Cypress tests for zoom enable/disable scenarios

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**BEFORE:** Compare BoxPlot with LinePlot (notice how BoxPlot has no Data Zoom Option)
<img width="956" height="416" alt="Issue 15 - Before" src="https://github.com/user-attachments/assets/f49d464c-a334-49ca-80f7-4ebf0ba9cd66" />


**AFTER:** BoxPlot with Data Zoom Option
<img width="959" height="413" alt="Issue 15 - After" src="https://github.com/user-attachments/assets/6653a4c4-7d79-4d8c-ae11-54c0d073b580" />

**DEMO VIDEO.** 
https://github.com/user-attachments/assets/f49b588d-a38e-4f5e-9013-a2f82d280f76


### TESTING INSTRUCTIONS

1. Create a BoxPlot chart with 10+ categories (e.g., `examples.birth_names` grouped by `name`)
2. Go to **Customize** tab → **Chart Options**
3. Enable **"Data Zoom"** checkbox and click "Update chart"
4. Verify zoom slider appears at bottom and mouse wheel pans horizontally
5. Disable and verify chart returns to static view

**Run tests:**
```bash
npm run cypress-run-chrome -- --spec cypress/e2e/explore/visualizations/box_plot.test.js
```

### ADDITIONAL INFORMATION

- [x] Has associated issue: #26 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
- [ ] Migration is atomic, supports rollback & is backwards-compatible
- [ ] Confirm DB migration upgrade and downgrade tested
- [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
